### PR TITLE
should be calling self for referencing static variable

### DIFF
--- a/src/DomainAuthority/DomainAuthorityException.php
+++ b/src/DomainAuthority/DomainAuthorityException.php
@@ -57,7 +57,7 @@ class DomainAuthorityException extends Exception {
             $code = -1;
 
         $this->code = $code;
-        $this->message = $messages[$code];
+        $this->message = self::$messages[$code];
     }
 
 }


### PR DESCRIPTION
Currently this is looking for the local variable messages, when in fact it is a static